### PR TITLE
fix: correct dtype for bounds in find_aoe

### DIFF
--- a/cython_extensions/combat_utils.pyx
+++ b/cython_extensions/combat_utils.pyx
@@ -264,9 +264,7 @@ cpdef cy_find_aoe_position(
     """
     Find the best place to put an AoE effect so that it hits the most units.
     """
-    cdef:
-        double x_min, x_max, y_min, y_max
-        unsigned int len_targets = len(targets)
+    cdef unsigned int len_targets = len(targets)
     if not bonus_tags:
         bonus_tags = set()
     if len_targets == 0:
@@ -274,14 +272,12 @@ cpdef cy_find_aoe_position(
     elif len_targets == 1:
         return targets.first.position
 
-    # Get bounding box
     (x_min, x_max), (y_min, y_max) = cy_get_bounding_box({u.position_tuple for u in targets})
-    cdef double[:, :] boundaries = np.array([[x_min, x_max], [y_min, y_max]])
+    bounds = [(x_min, x_max), (y_min, y_max)]
 
-    # OptimizeResult
     result = differential_evolution(
         f_wrapper,
-        bounds=boundaries,
+        bounds=bounds,
         args=(targets, effect_radius, bonus_tags),
         tol=1e-10
     )


### PR DESCRIPTION
Could be the cause of an occasional crash, `differential_evolution` will work with a np array for `bounds` but its not the expected datatype as SciPy tries to iterate over a list of tuples. 

No decreased performance from this change 