### PR TITLE
feat: dijkstra searches for valid starting point

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          fetch-depth: 0
       # install poetry
       - name: Install poetry
         run: pipx install poetry

--- a/cython_extensions/dijkstra.pyi
+++ b/cython_extensions/dijkstra.pyi
@@ -15,13 +15,14 @@ class DijkstraOutput:
     distance: np.ndarray
 
     def get_path(
-        self, source: tuple[int, int], limit: int = 0
+        self, source: tuple[float, float], limit: int = 0, max_distance: int = 1
     ) -> list[tuple[int, int]]:
         """Follow the path from a given source using the forward pointer grids.
 
         Args:
             source: Start point.
             limit: Maximum length of the returned path. Defaults to 0 indicating no limit.
+		    max_distance: Size of the search region for a valid starting point. Defaults to 1.
 
         Returns:
             The lowest cost path from source to any of the targets.

--- a/cython_extensions/dijkstra.pyx
+++ b/cython_extensions/dijkstra.pyx
@@ -61,7 +61,7 @@ cdef class DijkstraOutput:
 
         # check that source is within bounds
         if x < 0 or y < 0 or x >= self.distance.shape[0] or y >= self.distance.shape[1]:
-            return []
+            return [(x, y)]
 
         if limit == 0:
             # set a fallback limit to be safe

--- a/tests/test_dijkstra.py
+++ b/tests/test_dijkstra.py
@@ -16,7 +16,7 @@ MAPS: list[Path] = [
 ]
 
 
-class TestDijkstraFailcases:
+class TestDijkstraGeneric:
 
     def test_raises_on_nonpositive_entries(self):
         targets = np.array([[0, 0]])
@@ -44,6 +44,31 @@ class TestDijkstraFailcases:
             [[np.inf, np.inf, 2], [np.inf, np.inf, 1], [np.inf, np.inf, 2]]
         )
         assert_equal(pathing.distance, distance_expected)
+
+    def test_find_valid_start(self):
+        # test that the algorithm searches for valid starting point near the given coordinates
+        # setup a rectangular map surrounded by unpathable border
+        cost = np.pad(np.ones((3, 3)), 1, constant_values=np.inf)
+        # find paths towards center
+        pathing = cy_dijkstra(cost, np.array([[2, 2]]))
+        # test that starting point will be rounded
+        assert_equal(
+            pathing.get_path((1.1, 1.3)),
+            [(1, 1), (2, 2)]
+        )
+        assert_equal(
+            pathing.get_path((0.8, 0.7)),
+            [(1, 1), (2, 2)]
+        )
+        # test that invalid start snaps to the closest valid one
+        assert_equal(
+            pathing.get_path((0.1, 2)),
+            [(1, 2), (2, 2)]
+        )
+        assert_equal(
+            pathing.get_path((-2.2, 6.9), max_distance=5),
+            [(1, 3), (2, 2)]
+        )
 
 
 @pytest.mark.parametrize("bot", MAPS, indirect=True)


### PR DESCRIPTION
This PR adds a search step to the path lookup to find a valid starting point (with `pathing.distance[p] < inf`) near the given coordinates.

1. It allows the input coordinates to be `float` rather than `int`, so `pathing.get_path(unit.position)` can be used directly
2. It addresses an inconvenience that `unit.position.rounded` can fall outside the pathing grid if the unit is close to the edge.

A square region around the `float` coordinates is checked and the closest valid point is used. The size of the search region can be adjusted with a default of `max_distance=1` corresponding to a 3x3 square.

I think the lookup was also missing some bounds checks. With this change, the input coordinates are now allowed to fall outside the domain and the search should handle this correctly. The search may snap back into the domain if `max_distance` allows it.