### PR TITLE
feat: defer dijkstra evaluation

### DIFF
--- a/cython_extensions/dijkstra.pyi
+++ b/cython_extensions/dijkstra.pyi
@@ -1,18 +1,7 @@
 import numpy as np
 
-class DijkstraOutput:
-    """Result of Dijkstras algorithm containing distance and forward pointer grids.
-
-    Attributes:
-        forward_x: Forward pointer grid (x-coordinates).
-        forward_y: Forward pointer grid (y-coordinates).
-        distance: Distance grid.
-
-    """
-
-    forward_x: np.ndarray
-    forward_y: np.ndarray
-    distance: np.ndarray
+class DijkstraPathing:
+    """Result of Dijkstras algorithm containing distance and forward pointer grids."""
 
     def get_path(
         self, source: tuple[float, float], limit: int = 0, max_distance: int = 1
@@ -32,7 +21,7 @@ class DijkstraOutput:
 
 def cy_dijkstra(
     cost_grid: np.ndarray, targets: np.ndarray, checks_enabled: bool = True
-) -> DijkstraOutput:
+) -> DijkstraPathing:
     """Run Dijkstras algorithm on a grid, yielding many-target-shortest paths for each position.
 
     Example:

--- a/cython_extensions/dijkstra.pyi
+++ b/cython_extensions/dijkstra.pyi
@@ -39,8 +39,8 @@ def cy_dijkstra(
     ```py
     from cython_extensions import cy_dijkstra
 
-    targets = np.array([u.position.rounded for u in bot.enemy_units], np.intp)
-    cost = np.where(bot.game_info.pathing_grid.data_numpy.T == 1, 1.0, np.inf).astype(np.float64)
+    targets = np.array([u.position.rounded for u in bot.enemy_units])
+    cost = np.where(bot.game_info.pathing_grid.data_numpy.T == 1, 1.0, np.inf)
     pathing = cy_dijkstra(cost, targets)
 
     for unit in bot.units:

--- a/cython_extensions/dijkstra.pyx
+++ b/cython_extensions/dijkstra.pyx
@@ -1,244 +1,289 @@
-import numpy as np
-from cython import boundscheck, wraparound
+# cython: language_level=3
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: cdivision=True
+# cython: initializedcheck=False
+# cython: nonecheck=False
 
+import numpy as np
 cimport numpy as cnp
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
+from numpy.math cimport INFINITY
+from libc.math cimport sqrt, round, M_SQRT2
+from libc.stdint cimport int8_t
 
-DEF HEAP_ARITY = 4
+# -----------------------------------------------------------------------------
+# Types & Constants
+# -----------------------------------------------------------------------------
 
-ctypedef cnp.float64_t DTYPE_t
+ctypedef cnp.float32_t DTYPE_t
+ctypedef cnp.int32_t INDEX_t
+ctypedef int8_t DIR_t
 
-cdef Py_ssize_t[8] NEIGHBOURS_X = [-1, 1, 0, 0, -1, 1, -1, 1]
-cdef Py_ssize_t[8] NEIGHBOURS_Y = [0, 0, -1, 1, -1, -1, 1, 1]
-cdef DTYPE_t SQRT2 = np.sqrt(2)
-cdef DTYPE_t[8] NEIGHBOURS_D = [1, 1, 1, 1, SQRT2, SQRT2, SQRT2, SQRT2]
+cdef INDEX_t MIN_CAPACITY = 1024
+cdef DIR_t NO_DIRECTION = -1
+cdef INDEX_t NO_INDEX = -1
+cdef INDEX_t[8] OFFSET_X = [-1, 1, 0, 0, -1, -1, 1, 1]
+cdef INDEX_t[8] OFFSET_Y = [0, 0, -1, 1, -1, 1, -1, 1]
+cdef DTYPE_t[8] COST_DIRECTION = [1.0, 1.0, 1.0, 1.0, M_SQRT2, M_SQRT2, M_SQRT2, M_SQRT2]
 
+# -----------------------------------------------------------------------------
+# Heap Operations
+# -----------------------------------------------------------------------------
 
-cdef struct PriorityQueueItem:
-    Py_ssize_t x, y
-    DTYPE_t distance
-
-
-cdef class DijkstraOutput:
-    cdef public Py_ssize_t[:, :] forward_x
-    """Forward pointer grid (x-coordinates)."""
-    cdef public Py_ssize_t[:, :] forward_y
-    """Forward pointer grid (y-coordinates)."""
-    cdef public DTYPE_t[:, :] distance
-    """Distance grid."""
-    def __cinit__(self,
-                  Py_ssize_t[:, :] forward_x,
-                  Py_ssize_t[:, :] forward_y,
-                  DTYPE_t[:, :] distance):
-        self.forward_x = forward_x
-        self.forward_y = forward_y
-        self.distance = distance
-
-    @boundscheck(False)
-    @wraparound(False)
-    cpdef get_path(self, (float, float) source, int limit=0, int max_distance=1):
-        """
-
-        Follow the path from a given source using the forward pointer grids.
-
-        Parameters
-        ----------
-        source :
-            Start point.
-        limit :
-            Maximum length of the returned path. Defaults to 0 indicating no limit.
-        max_distance :
-            Size of the search region for a valid starting point. Defaults to 1.
-
-        Returns
-        -------
-        list[tuple[int, int]] :
-            The lowest cost path from source to any of the targets.
-
-        """
-        path = list[tuple[int, int]]()
-        x, y = self.get_closest_reachable_point(source, max_distance=max_distance)
-
-        # check that source is within bounds
-        if x < 0 or y < 0 or x >= self.distance.shape[0] or y >= self.distance.shape[1]:
-            return [(x, y)]
-
-        if limit == 0:
-            # set a fallback limit to be safe
-            # a path longer than this must contain a cycle, so it should never be hit anyway
-            limit = self.distance.shape[0] * self.distance.shape[1]
-
-        while len(path) < limit:
-            if x < 0 or y < 0:
-                # pointer value of -1 marks no pointer
-                break
-            path.append((x, y))
-            x, y = self.forward_x[x, y], self.forward_y[x, y]
-        return path
-
-    @boundscheck(False)
-    @wraparound(False)
-    cpdef (int, int) get_closest_reachable_point(self, (float, float) source, int max_distance):
-        """
-
-        Search the region for a point that can reach a target.
-
-        Parameters
-        ----------
-        source :
-            Start point as float coordinates.
-        limit :
-            Maximum distance between the source and returned point.
-
-        Returns
-        -------
-        tuple[int, int] :
-            The closest integer coordinates to the source with finite distance.
-
-        """
-        x0 = int(source[0])
-        y0 = int(source[1])
-
-        x_min = x0
-        y_min = y0
-        min_distance_squared = np.inf
-
-        for x in range(max(0, x0 - max_distance), min(self.distance.shape[0], x0 + max_distance + 1)):
-            for y in range(max(0, y0 - max_distance), min(self.distance.shape[1], y0 + max_distance + 1)):
-                if self.distance[x, y] < np.inf:
-                    distance_squared = (x - source[0]) ** 2 + (y - source[1]) ** 2
-                    if distance_squared < min_distance_squared:
-                        x_min = x
-                        y_min = y
-                        min_distance_squared = distance_squared
-
-        return x_min, y_min
-
-
-@boundscheck(False)
-@wraparound(False)
-cpdef DijkstraOutput cy_dijkstra(
-    DTYPE_t[:, :] cost,
-    Py_ssize_t[:, :] targets,
-    bint checks_enabled = True,
+cdef inline void bubble_up(
+    INDEX_t* index,
+    DTYPE_t* priority,
+    INDEX_t* indirection,
+    INDEX_t i
 ):
-    """
+    cdef INDEX_t parent
+    cdef INDEX_t move_index = index[i]
+    cdef DTYPE_t move_priority = priority[i]
+    while i > 0:
+        parent = (i - 1) >> 1
+        if move_priority < priority[parent]:
+            index[i] = index[parent]
+            priority[i] = priority[parent]
+            indirection[index[i]] = i
+            i = parent
+        else:
+            break
+    index[i] = move_index
+    priority[i] = move_priority
+    indirection[move_index] = i
 
-    Run Dijkstras algorithm on a grid, yielding many-target-shortest paths for each position.
+cdef inline void bubble_down(
+    INDEX_t* index,
+    DTYPE_t* priority,
+    INDEX_t* indirection,
+    INDEX_t i,
+    INDEX_t size,
+):
+    cdef INDEX_t child
+    cdef INDEX_t move_index = index[i]
+    cdef DTYPE_t move_priority = priority[i]
+    cdef INDEX_t half_size = size >> 1
+    while i < half_size:
+        child = (i << 1) + 1
+        if child + 1 < size and priority[child + 1] < priority[child]:
+            child += 1
+        if move_priority <= priority[child]:
+            break
+        index[i] = index[child]
+        priority[i] = priority[child]
+        indirection[index[i]] = i
+        i = child
+    index[i] = move_index
+    priority[i] = move_priority
+    indirection[move_index] = i
 
-    Parameters
-    ----------
-    cost :
-        Cost grid. Entries must be positive. Set unpathable cells to infinity.
-    targets :
-        Target array of shape (*, 2) containing x and y coordinates of the target points.
-    checks_enabled :
-        Pass False to deactivate grid value and target coordinates checks. Defaults to True.
+cdef inline void grow_heap(
+    INDEX_t** index_ptr,
+    DTYPE_t** priority_ptr,
+    INDEX_t* capacity_ptr
+) except *:
+    cdef INDEX_t new_capacity = capacity_ptr[0] * 2
+    cdef INDEX_t* new_index = <INDEX_t*>PyMem_Realloc(index_ptr[0], new_capacity * sizeof(INDEX_t))
+    if not new_index:
+        raise MemoryError("Heap allocation failed in cy_dijkstra.")
+    index_ptr[0] = new_index
+    cdef DTYPE_t* new_priority = <DTYPE_t*>PyMem_Realloc(priority_ptr[0], new_capacity * sizeof(DTYPE_t))
+    if not new_priority:
+        raise MemoryError("Heap allocation failed in cy_dijkstra.")
+    priority_ptr[0] = new_priority
+    capacity_ptr[0] = new_capacity
 
-    Returns
-    -------
-    DijkstraOutput :
-        Pathfinding object containing containing distance and forward pointer grids.
+# -----------------------------------------------------------------------------
+# Core Algorithm
+# -----------------------------------------------------------------------------
 
-    """
+cdef void dijkstra_core(
+    INDEX_t** index_ptr,
+    DTYPE_t** priority_ptr,
+    INDEX_t* capacity_ptr,
+    INDEX_t* indirection,
+    INDEX_t* size_ptr,
+    INDEX_t start,
+    DTYPE_t* distance,
+    DTYPE_t* cost,
+    DIR_t* direction,
+    INDEX_t stride
+):
 
     cdef:
-        PriorityQueueItem* heap
-        PriorityQueueItem root
-        Py_ssize_t i, swap, index, parent
+        INDEX_t i, neighbour, k
+        DTYPE_t d, alternative
+        INDEX_t* index = index_ptr[0]
+        DTYPE_t* priority = priority_ptr[0]
+        INDEX_t size = size_ptr[0]
+        INDEX_t[8] offsets = [-stride, stride, -1, 1, -stride - 1, -stride + 1, stride - 1, stride + 1]
 
-        PriorityQueueItem u
-        Py_ssize_t capacity, size
-        Py_ssize_t x, y, x2, y2
-        DTYPE_t c, alternative
-        DTYPE_t[:, :] cost_padded = np.pad(cost, 1, "constant", constant_values=np.inf)
-        DTYPE_t[:, :] distance = np.full_like(cost, np.inf)
-        Py_ssize_t[:, :] forward_x = np.full_like(cost, -1, np.intp)
-        Py_ssize_t[:, :] forward_y = np.full_like(cost, -1, np.intp)
+    while size > 0 and priority[0] < distance[start]:
 
-    if checks_enabled:
-        if np.any(np.less_equal(cost, 0.0)):
-            raise Exception("invalid cost: entries must be strictly positive")
-
-        if any((
-            np.less(targets, 0).any(),
-            np.greater_equal(targets[:, 0], cost.shape[0]).any(),
-            np.greater_equal(targets[:, 1], cost.shape[1]).any(),
-        )):
-            raise Exception(f"Target out of bounds")
-
-    capacity = targets.shape[0]
-    heap = <PriorityQueueItem*>PyMem_Malloc(capacity * sizeof(PriorityQueueItem))
-    if not heap:
-        raise MemoryError()
-    size = capacity
-
-    # initialize queue with targets
-    for i in range(targets.shape[0]):
-
-        # add to heap
-        x = targets[i, 0]
-        y = targets[i, 1]
-        c = cost[x, y]
-        heap[i] = PriorityQueueItem(x, y, c)
-        distance[x, y] = c
-
-        # heapify
-        index = i
-        while index != 0:
-            parent = (index - 1) // HEAP_ARITY
-            if heap[index].distance < heap[parent].distance:
-                heap[index], heap[parent] = heap[parent], heap[index]
-                index = parent
-            else:
-                break
-
-    while size != 0:
-
-        x = heap[0].x
-        y = heap[0].y
-
-        # dequeue
+        # pop minimum
+        i = index[0]
+        d = priority[0]
+        indirection[i] = NO_INDEX
         size -= 1
-        heap[0] = heap[size]
-        index = 0
-        while True:
-            swap = index
-            i = HEAP_ARITY * index + 1
-            for child in range(i, i + min(HEAP_ARITY, size - i)):
-                if heap[child].distance < heap[swap].distance:
-                    swap = child
-            if swap != index:
-                heap[index], heap[swap] = heap[swap], heap[index]
-                index = swap
-            else:
-                break
+        if size > 0:
+            index[0] = index[size]
+            priority[0] = priority[size]
+            indirection[index[0]] = 0
+            bubble_down(index, priority, indirection, 0, size)
 
+        # iterate neighbours
         for k in range(8):
-            x2 = x + NEIGHBOURS_X[k]
-            y2 = y + NEIGHBOURS_Y[k]
-            alternative = distance[x, y] + NEIGHBOURS_D[k] * cost_padded[x2+1, y2+1]
-            if alternative < distance[x2, y2]:
-                distance[x2, y2] = alternative
-                forward_x[x2, y2] = x
-                forward_y[x2, y2] = y
+            neighbour = i + offsets[k]
+            alternative = d + COST_DIRECTION[k] * cost[neighbour]
+            if alternative < distance[neighbour]:
+                distance[neighbour] = alternative
+                direction[neighbour] = <DIR_t>k
 
-                # enqueue
-                index = size
-                size += 1
-                if size > capacity:
-                    capacity *= HEAP_ARITY
-                    heap = <PriorityQueueItem*>PyMem_Realloc(heap, capacity * sizeof(PriorityQueueItem))
-                    if not heap:
-                        raise MemoryError()
-                heap[index] = PriorityQueueItem(x2, y2, alternative)
-                while index != 0:
-                    parent = (index - 1) // HEAP_ARITY
-                    if heap[index].distance < heap[parent].distance:
-                        heap[index], heap[parent] = heap[parent], heap[index]
-                        index = parent
-                    else:
-                        break
+                if indirection[neighbour] != NO_INDEX:
+                    # node already in heap, decrease key
+                    priority[indirection[neighbour]] = alternative
+                    bubble_up(index, priority, indirection, indirection[neighbour])
 
-    PyMem_Free(heap)
-    return DijkstraOutput(forward_x, forward_y, distance)
+                else:
+                    # dynamic resize
+                    if size >= capacity_ptr[0]:
+                        grow_heap(index_ptr, priority_ptr, capacity_ptr)
+                        index = index_ptr[0]
+                        priority = priority_ptr[0]
+                    # enqueue
+                    index[size] = neighbour
+                    priority[size] = alternative
+                    indirection[neighbour] = size
+                    bubble_up(index, priority, indirection, size)
+                    size += 1
+
+    size_ptr[0] = size
+
+# -----------------------------------------------------------------------------
+# Python Interface
+# -----------------------------------------------------------------------------
+
+cdef class DijkstraOutput:
+    cdef public DIR_t[:, ::1] direction
+    cdef public DTYPE_t[:, ::1] distance
+
+    cdef INDEX_t* index
+    cdef DTYPE_t* priority
+    cdef INDEX_t capacity
+    cdef DTYPE_t[:, ::1] cost
+    cdef INDEX_t[:, ::1] indirection
+    cdef INDEX_t size
+    cdef INDEX_t stride
+
+    def __cinit__(self,
+                  DTYPE_t[:, ::1] cost,
+                  INDEX_t[:, ::1] targets):
+        cdef INDEX_t num_targets = targets.shape[0]
+        self.cost = np.pad(cost, 1, "constant", constant_values=INFINITY)
+        self.stride = self.cost.shape[1]
+        self.direction = np.full_like(self.cost, NO_DIRECTION, dtype=np.int8)
+        self.indirection = np.full_like(self.cost, NO_INDEX, dtype=np.int32)
+        self.distance = np.full_like(self.cost, INFINITY)
+        self.capacity = max(MIN_CAPACITY, 2 * num_targets)
+        self.size = 0
+        self.index = <INDEX_t*>PyMem_Malloc(self.capacity * sizeof(INDEX_t))
+        self.priority = <DTYPE_t*>PyMem_Malloc(self.capacity * sizeof(DTYPE_t))
+        if not self.index or not self.priority:
+            raise MemoryError("Could not allocate heap memory")
+        for k in range(num_targets):
+            self._add_target(self.stride * (targets[k, 0] + 1) + (targets[k, 1] + 1))
+
+    cdef void _add_target(self, INDEX_t i):
+        cdef INDEX_t* indirection = &self.indirection[0,0]
+        cdef DTYPE_t* distance = &self.distance[0,0]
+        cdef DTYPE_t* cost = &self.cost[0,0]
+        c = cost[i]
+        if c == INFINITY:
+            return
+        self.index[self.size] = i
+        self.priority[self.size] = c
+        indirection[i] = self.size
+        distance[i] = c
+        bubble_up(self.index, self.priority, indirection, self.size)
+        self.size += 1
+
+    def __dealloc__(self):
+        PyMem_Free(self.index)
+        PyMem_Free(self.priority)
+
+    cpdef get_path(self, object source, int limit=0, int max_distance=1):
+        # find start integer coordinates
+        cdef INDEX_t x0, y0
+        x0, y0 = self._find_starting_point(np.asarray(source, dtype=np.float32), max_distance=max_distance)
+        if x0 < 0 or y0 < 0 or x0 >= self.cost.shape[0] or y0 >= self.cost.shape[1] or self.cost[x0, y0] == INFINITY:
+            return [(x0 - 1, y0 - 1)]
+        dijkstra_core(
+            &self.index,
+            &self.priority,
+            &self.capacity,
+            &self.indirection[0, 0],
+            &self.size,
+            x0 * self.stride + y0,
+            &self.distance[0, 0],
+            &self.cost[0, 0],
+            &self.direction[0, 0],
+            self.stride
+        )
+        return self._follow_directions(x0, y0, limit)
+
+    cdef _follow_directions(self, INDEX_t x, INDEX_t y, INDEX_t limit):
+        if limit == 0:
+            limit = self.distance.size
+        path = []
+        while len(path) < limit:
+            path.append((x - 1, y - 1))
+            k = self.direction[x, y]
+            if k == NO_DIRECTION:
+                break
+            x -= OFFSET_X[k]
+            y -= OFFSET_Y[k]
+        return path
+
+    cdef (INDEX_t, INDEX_t) _find_starting_point(self, DTYPE_t[:] source, int max_distance):
+        # +1 for padding
+        cdef DTYPE_t fx0 = source[0] + 1
+        cdef DTYPE_t fy0 = source[1] + 1
+        cdef INDEX_t x0 = <INDEX_t>round(fx0)
+        cdef INDEX_t y0 = <INDEX_t>round(fy0)
+        cdef INDEX_t x_min = x0
+        cdef INDEX_t y_min = y0
+        cdef DTYPE_t min_d2 = INFINITY
+        cdef DTYPE_t d2
+        cdef INDEX_t x, y
+        cdef INDEX_t x_start = max(1, x0 - max_distance)
+        cdef INDEX_t x_end = min(self.distance.shape[0] - 1, x0 + max_distance + 1)
+        cdef INDEX_t y_start = max(1, y0 - max_distance)
+        cdef INDEX_t y_end = min(self.distance.shape[1] - 1, y0 + max_distance + 1)
+        for x in range(x_start, x_end):
+            for y in range(y_start, y_end):
+                if self.cost[x, y] != INFINITY:
+                    d2 = (x - fx0)**2 + (y - fy0)**2
+                    if d2 < min_d2:
+                        min_d2 = d2
+                        x_min = x
+                        y_min = y
+        return x_min, y_min
+
+cpdef DijkstraOutput cy_dijkstra(
+    object cost,
+    object targets,
+    bint checks_enabled = True,
+):
+    cdef DTYPE_t[:, ::1] cost_array = np.ascontiguousarray(cost, dtype=np.float32)
+    cdef INDEX_t[:, ::1] target_array = np.ascontiguousarray(targets, dtype=np.int32)
+    if checks_enabled:
+        if not np.greater(cost_array, 0.0).all():
+            raise Exception("invalid cost: values must be positive")
+        if (
+            not np.greater_equal(targets, 0).all()
+            or not np.less(targets[:, 0], cost.shape[0]).all()
+            or not np.less(targets[:, 1], cost.shape[1]).all()
+        ):
+            raise Exception(f"invalid target: coordinates out of bounds")
+    return DijkstraOutput(cost_array, target_array)

--- a/notebooks/dijkstra.ipynb
+++ b/notebooks/dijkstra.ipynb
@@ -9,28 +9,18 @@
   {
    "cell_type": "code",
    "id": "ed24b807-8666-46d5-822d-c5345890cbaa",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-04-04T18:54:00.340889Z",
-     "start_time": "2025-04-04T18:54:00.337079Z"
-    }
-   },
+   "metadata": {},
    "source": [
     "# Change path as needed\n",
     "MAP_PATH = \"../tests/pickle_data/AncientCisternAIE.xz\""
    ],
    "outputs": [],
-   "execution_count": 1
+   "execution_count": null
   },
   {
    "cell_type": "code",
    "id": "832ef3d4-55c0-4c5f-b2a3-324444e90539",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-04-04T18:54:01.165880Z",
-     "start_time": "2025-04-04T18:54:00.499825Z"
-    }
-   },
+   "metadata": {},
    "source": [
     "# load cell magic things\n",
     "%matplotlib notebook\n",
@@ -38,17 +28,12 @@
     "%load_ext Cython"
    ],
    "outputs": [],
-   "execution_count": 2
+   "execution_count": null
   },
   {
    "cell_type": "code",
    "id": "43e201a3-e828-4568-b1ee-802502cf4ee6",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-04-04T18:54:01.884156Z",
-     "start_time": "2025-04-04T18:54:01.174791Z"
-    }
-   },
+   "metadata": {},
    "source": [
     "# imports\n",
     "from matplotlib.backend_bases import MouseButton\n",
@@ -68,31 +53,21 @@
     "from tests.load_bot_from_pickle import get_map_specific_bot"
    ],
    "outputs": [],
-   "execution_count": 3
+   "execution_count": null
   },
   {
    "cell_type": "code",
    "id": "f7ded910-3843-4148-9c48-4acdaf81bbd0",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-04-04T18:54:01.964008Z",
-     "start_time": "2025-04-04T18:54:01.894458Z"
-    }
-   },
+   "metadata": {},
    "source": [
     "# setup a burnysc2 BOTAI instance we can test with\n",
     "bot: BotAI = get_map_specific_bot(MAP_PATH)"
    ],
    "outputs": [],
-   "execution_count": 4
+   "execution_count": null
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-04-04T18:54:01.981952Z",
-     "start_time": "2025-04-04T18:54:01.978825Z"
-    }
-   },
+   "metadata": {},
    "cell_type": "code",
    "source": [
     "cost = np.where(bot.game_info.pathing_grid.data_numpy.T == 1, 1.0, np.inf)\n",
@@ -100,41 +75,47 @@
    ],
    "id": "32568a9857fe459c",
    "outputs": [],
-   "execution_count": 5
+   "execution_count": null
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-04-04T18:54:02.071216Z",
-     "start_time": "2025-04-04T18:54:01.990013Z"
-    }
-   },
+   "metadata": {},
+   "cell_type": "code",
+   "source": "%timeit cy_dijkstra(cost, targets_test).get_path(bot.enemy_start_locations[0])",
+   "id": "104dd9a70768eb3",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
    "cell_type": "code",
    "source": [
-    "%%timeit -n 10\n",
-    "cy_dijkstra(cost, targets_test)"
+    "pathing = cy_dijkstra(cost, targets_test)\n",
+    "pathing.get_path(bot.enemy_start_locations[0], 3)"
    ],
-   "id": "104dd9a70768eb3",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1.08 ms ± 149 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
-     ]
-    }
-   ],
-   "execution_count": 6
+   "id": "676a44e3e5484c71",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "%timeit pathing.get_path(bot.enemy_start_locations[0])",
+   "id": "77e0a431c03650cb",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "%timeit pathing.get_path(bot.enemy_start_locations[0], 3)",
+   "id": "4d44170637d32b0a",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
    "id": "9f5fb567-809a-4823-aefa-569a2b21cf25",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-04-04T18:54:02.120881Z",
-     "start_time": "2025-04-04T18:54:02.090211Z"
-    }
-   },
+   "metadata": {},
    "source": [
     "pathing = None\n",
     "targets = set()\n",
@@ -149,7 +130,7 @@
     "    if pathing is None:\n",
     "        data = cost\n",
     "    else:\n",
-    "        data = pathing.distance.copy()\n",
+    "        data = cost.copy()\n",
     "        for p in pathing.get_path(source):\n",
     "            data[p] = np.nan\n",
     "        for t in targets:\n",
@@ -179,31 +160,8 @@
     "fig.canvas.mpl_connect('motion_notify_event', pick_source)\n",
     "plt.show()"
    ],
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ],
-      "application/javascript": "/* Put everything inside the global mpl namespace */\n/* global mpl */\nwindow.mpl = {};\n\nmpl.get_websocket_type = function () {\n    if (typeof WebSocket !== 'undefined') {\n        return WebSocket;\n    } else if (typeof MozWebSocket !== 'undefined') {\n        return MozWebSocket;\n    } else {\n        alert(\n            'Your browser does not have WebSocket support. ' +\n                'Please try Chrome, Safari or Firefox ≥ 6. ' +\n                'Firefox 4 and 5 are also supported but you ' +\n                'have to enable WebSockets in about:config.'\n        );\n    }\n};\n\nmpl.figure = function (figure_id, websocket, ondownload, parent_element) {\n    this.id = figure_id;\n\n    this.ws = websocket;\n\n    this.supports_binary = this.ws.binaryType !== undefined;\n\n    if (!this.supports_binary) {\n        var warnings = document.getElementById('mpl-warnings');\n        if (warnings) {\n            warnings.style.display = 'block';\n            warnings.textContent =\n                'This browser does not support binary websocket messages. ' +\n                'Performance may be slow.';\n        }\n    }\n\n    this.imageObj = new Image();\n\n    this.context = undefined;\n    this.message = undefined;\n    this.canvas = undefined;\n    this.rubberband_canvas = undefined;\n    this.rubberband_context = undefined;\n    this.format_dropdown = undefined;\n\n    this.image_mode = 'full';\n\n    this.root = document.createElement('div');\n    this.root.setAttribute('style', 'display: inline-block');\n    this._root_extra_style(this.root);\n\n    parent_element.appendChild(this.root);\n\n    this._init_header(this);\n    this._init_canvas(this);\n    this._init_toolbar(this);\n\n    var fig = this;\n\n    this.waiting = false;\n\n    this.ws.onopen = function () {\n        fig.send_message('supports_binary', { value: fig.supports_binary });\n        fig.send_message('send_image_mode', {});\n        if (fig.ratio !== 1) {\n            fig.send_message('set_device_pixel_ratio', {\n                device_pixel_ratio: fig.ratio,\n            });\n        }\n        fig.send_message('refresh', {});\n    };\n\n    this.imageObj.onload = function () {\n        if (fig.image_mode === 'full') {\n            // Full images could contain transparency (where diff images\n            // almost always do), so we need to clear the canvas so that\n            // there is no ghosting.\n            fig.context.clearRect(0, 0, fig.canvas.width, fig.canvas.height);\n        }\n        fig.context.drawImage(fig.imageObj, 0, 0);\n    };\n\n    this.imageObj.onunload = function () {\n        fig.ws.close();\n    };\n\n    this.ws.onmessage = this._make_on_message_function(this);\n\n    this.ondownload = ondownload;\n};\n\nmpl.figure.prototype._init_header = function () {\n    var titlebar = document.createElement('div');\n    titlebar.classList =\n        'ui-dialog-titlebar ui-widget-header ui-corner-all ui-helper-clearfix';\n    var titletext = document.createElement('div');\n    titletext.classList = 'ui-dialog-title';\n    titletext.setAttribute(\n        'style',\n        'width: 100%; text-align: center; padding: 3px;'\n    );\n    titlebar.appendChild(titletext);\n    this.root.appendChild(titlebar);\n    this.header = titletext;\n};\n\nmpl.figure.prototype._canvas_extra_style = function (_canvas_div) {};\n\nmpl.figure.prototype._root_extra_style = function (_canvas_div) {};\n\nmpl.figure.prototype._init_canvas = function () {\n    var fig = this;\n\n    var canvas_div = (this.canvas_div = document.createElement('div'));\n    canvas_div.setAttribute('tabindex', '0');\n    canvas_div.setAttribute(\n        'style',\n        'border: 1px solid #ddd;' +\n            'box-sizing: content-box;' +\n            'clear: both;' +\n            'min-height: 1px;' +\n            'min-width: 1px;' +\n            'outline: 0;' +\n            'overflow: hidden;' +\n            'position: relative;' +\n            'resize: both;' +\n            'z-index: 2;'\n    );\n\n    function on_keyboard_event_closure(name) {\n        return function (event) {\n            return fig.key_event(event, name);\n        };\n    }\n\n    canvas_div.addEventListener(\n        'keydown',\n        on_keyboard_event_closure('key_press')\n    );\n    canvas_div.addEventListener(\n        'keyup',\n        on_keyboard_event_closure('key_release')\n    );\n\n    this._canvas_extra_style(canvas_div);\n    this.root.appendChild(canvas_div);\n\n    var canvas = (this.canvas = document.createElement('canvas'));\n    canvas.classList.add('mpl-canvas');\n    canvas.setAttribute(\n        'style',\n        'box-sizing: content-box;' +\n            'pointer-events: none;' +\n            'position: relative;' +\n            'z-index: 0;'\n    );\n\n    this.context = canvas.getContext('2d');\n\n    var backingStore =\n        this.context.backingStorePixelRatio ||\n        this.context.webkitBackingStorePixelRatio ||\n        this.context.mozBackingStorePixelRatio ||\n        this.context.msBackingStorePixelRatio ||\n        this.context.oBackingStorePixelRatio ||\n        this.context.backingStorePixelRatio ||\n        1;\n\n    this.ratio = (window.devicePixelRatio || 1) / backingStore;\n\n    var rubberband_canvas = (this.rubberband_canvas = document.createElement(\n        'canvas'\n    ));\n    rubberband_canvas.setAttribute(\n        'style',\n        'box-sizing: content-box;' +\n            'left: 0;' +\n            'pointer-events: none;' +\n            'position: absolute;' +\n            'top: 0;' +\n            'z-index: 1;'\n    );\n\n    // Apply a ponyfill if ResizeObserver is not implemented by browser.\n    if (this.ResizeObserver === undefined) {\n        if (window.ResizeObserver !== undefined) {\n            this.ResizeObserver = window.ResizeObserver;\n        } else {\n            var obs = _JSXTOOLS_RESIZE_OBSERVER({});\n            this.ResizeObserver = obs.ResizeObserver;\n        }\n    }\n\n    this.resizeObserverInstance = new this.ResizeObserver(function (entries) {\n        // There's no need to resize if the WebSocket is not connected:\n        // - If it is still connecting, then we will get an initial resize from\n        //   Python once it connects.\n        // - If it has disconnected, then resizing will clear the canvas and\n        //   never get anything back to refill it, so better to not resize and\n        //   keep something visible.\n        if (fig.ws.readyState != 1) {\n            return;\n        }\n        var nentries = entries.length;\n        for (var i = 0; i < nentries; i++) {\n            var entry = entries[i];\n            var width, height;\n            if (entry.contentBoxSize) {\n                if (entry.contentBoxSize instanceof Array) {\n                    // Chrome 84 implements new version of spec.\n                    width = entry.contentBoxSize[0].inlineSize;\n                    height = entry.contentBoxSize[0].blockSize;\n                } else {\n                    // Firefox implements old version of spec.\n                    width = entry.contentBoxSize.inlineSize;\n                    height = entry.contentBoxSize.blockSize;\n                }\n            } else {\n                // Chrome <84 implements even older version of spec.\n                width = entry.contentRect.width;\n                height = entry.contentRect.height;\n            }\n\n            // Keep the size of the canvas and rubber band canvas in sync with\n            // the canvas container.\n            if (entry.devicePixelContentBoxSize) {\n                // Chrome 84 implements new version of spec.\n                canvas.setAttribute(\n                    'width',\n                    entry.devicePixelContentBoxSize[0].inlineSize\n                );\n                canvas.setAttribute(\n                    'height',\n                    entry.devicePixelContentBoxSize[0].blockSize\n                );\n            } else {\n                canvas.setAttribute('width', width * fig.ratio);\n                canvas.setAttribute('height', height * fig.ratio);\n            }\n            /* This rescales the canvas back to display pixels, so that it\n             * appears correct on HiDPI screens. */\n            canvas.style.width = width + 'px';\n            canvas.style.height = height + 'px';\n\n            rubberband_canvas.setAttribute('width', width);\n            rubberband_canvas.setAttribute('height', height);\n\n            // And update the size in Python. We ignore the initial 0/0 size\n            // that occurs as the element is placed into the DOM, which should\n            // otherwise not happen due to the minimum size styling.\n            if (width != 0 && height != 0) {\n                fig.request_resize(width, height);\n            }\n        }\n    });\n    this.resizeObserverInstance.observe(canvas_div);\n\n    function on_mouse_event_closure(name) {\n        /* User Agent sniffing is bad, but WebKit is busted:\n         * https://bugs.webkit.org/show_bug.cgi?id=144526\n         * https://bugs.webkit.org/show_bug.cgi?id=181818\n         * The worst that happens here is that they get an extra browser\n         * selection when dragging, if this check fails to catch them.\n         */\n        var UA = navigator.userAgent;\n        var isWebKit = /AppleWebKit/.test(UA) && !/Chrome/.test(UA);\n        if(isWebKit) {\n            return function (event) {\n                /* This prevents the web browser from automatically changing to\n                 * the text insertion cursor when the button is pressed. We\n                 * want to control all of the cursor setting manually through\n                 * the 'cursor' event from matplotlib */\n                event.preventDefault()\n                return fig.mouse_event(event, name);\n            };\n        } else {\n            return function (event) {\n                return fig.mouse_event(event, name);\n            };\n        }\n    }\n\n    canvas_div.addEventListener(\n        'mousedown',\n        on_mouse_event_closure('button_press')\n    );\n    canvas_div.addEventListener(\n        'mouseup',\n        on_mouse_event_closure('button_release')\n    );\n    canvas_div.addEventListener(\n        'dblclick',\n        on_mouse_event_closure('dblclick')\n    );\n    // Throttle sequential mouse events to 1 every 20ms.\n    canvas_div.addEventListener(\n        'mousemove',\n        on_mouse_event_closure('motion_notify')\n    );\n\n    canvas_div.addEventListener(\n        'mouseenter',\n        on_mouse_event_closure('figure_enter')\n    );\n    canvas_div.addEventListener(\n        'mouseleave',\n        on_mouse_event_closure('figure_leave')\n    );\n\n    canvas_div.addEventListener('wheel', function (event) {\n        if (event.deltaY < 0) {\n            event.step = 1;\n        } else {\n            event.step = -1;\n        }\n        on_mouse_event_closure('scroll')(event);\n    });\n\n    canvas_div.appendChild(canvas);\n    canvas_div.appendChild(rubberband_canvas);\n\n    this.rubberband_context = rubberband_canvas.getContext('2d');\n    this.rubberband_context.strokeStyle = '#000000';\n\n    this._resize_canvas = function (width, height, forward) {\n        if (forward) {\n            canvas_div.style.width = width + 'px';\n            canvas_div.style.height = height + 'px';\n        }\n    };\n\n    // Disable right mouse context menu.\n    canvas_div.addEventListener('contextmenu', function (_e) {\n        event.preventDefault();\n        return false;\n    });\n\n    function set_focus() {\n        canvas.focus();\n        canvas_div.focus();\n    }\n\n    window.setTimeout(set_focus, 100);\n};\n\nmpl.figure.prototype._init_toolbar = function () {\n    var fig = this;\n\n    var toolbar = document.createElement('div');\n    toolbar.classList = 'mpl-toolbar';\n    this.root.appendChild(toolbar);\n\n    function on_click_closure(name) {\n        return function (_event) {\n            return fig.toolbar_button_onclick(name);\n        };\n    }\n\n    function on_mouseover_closure(tooltip) {\n        return function (event) {\n            if (!event.currentTarget.disabled) {\n                return fig.toolbar_button_onmouseover(tooltip);\n            }\n        };\n    }\n\n    fig.buttons = {};\n    var buttonGroup = document.createElement('div');\n    buttonGroup.classList = 'mpl-button-group';\n    for (var toolbar_ind in mpl.toolbar_items) {\n        var name = mpl.toolbar_items[toolbar_ind][0];\n        var tooltip = mpl.toolbar_items[toolbar_ind][1];\n        var image = mpl.toolbar_items[toolbar_ind][2];\n        var method_name = mpl.toolbar_items[toolbar_ind][3];\n\n        if (!name) {\n            /* Instead of a spacer, we start a new button group. */\n            if (buttonGroup.hasChildNodes()) {\n                toolbar.appendChild(buttonGroup);\n            }\n            buttonGroup = document.createElement('div');\n            buttonGroup.classList = 'mpl-button-group';\n            continue;\n        }\n\n        var button = (fig.buttons[name] = document.createElement('button'));\n        button.classList = 'mpl-widget';\n        button.setAttribute('role', 'button');\n        button.setAttribute('aria-disabled', 'false');\n        button.addEventListener('click', on_click_closure(method_name));\n        button.addEventListener('mouseover', on_mouseover_closure(tooltip));\n\n        var icon_img = document.createElement('img');\n        icon_img.src = '_images/' + image + '.png';\n        icon_img.srcset = '_images/' + image + '_large.png 2x';\n        icon_img.alt = tooltip;\n        button.appendChild(icon_img);\n\n        buttonGroup.appendChild(button);\n    }\n\n    if (buttonGroup.hasChildNodes()) {\n        toolbar.appendChild(buttonGroup);\n    }\n\n    var fmt_picker = document.createElement('select');\n    fmt_picker.classList = 'mpl-widget';\n    toolbar.appendChild(fmt_picker);\n    this.format_dropdown = fmt_picker;\n\n    for (var ind in mpl.extensions) {\n        var fmt = mpl.extensions[ind];\n        var option = document.createElement('option');\n        option.selected = fmt === mpl.default_extension;\n        option.innerHTML = fmt;\n        fmt_picker.appendChild(option);\n    }\n\n    var status_bar = document.createElement('span');\n    status_bar.classList = 'mpl-message';\n    toolbar.appendChild(status_bar);\n    this.message = status_bar;\n};\n\nmpl.figure.prototype.request_resize = function (x_pixels, y_pixels) {\n    // Request matplotlib to resize the figure. Matplotlib will then trigger a resize in the client,\n    // which will in turn request a refresh of the image.\n    this.send_message('resize', { width: x_pixels, height: y_pixels });\n};\n\nmpl.figure.prototype.send_message = function (type, properties) {\n    properties['type'] = type;\n    properties['figure_id'] = this.id;\n    this.ws.send(JSON.stringify(properties));\n};\n\nmpl.figure.prototype.send_draw_message = function () {\n    if (!this.waiting) {\n        this.waiting = true;\n        this.ws.send(JSON.stringify({ type: 'draw', figure_id: this.id }));\n    }\n};\n\nmpl.figure.prototype.handle_save = function (fig, _msg) {\n    var format_dropdown = fig.format_dropdown;\n    var format = format_dropdown.options[format_dropdown.selectedIndex].value;\n    fig.ondownload(fig, format);\n};\n\nmpl.figure.prototype.handle_resize = function (fig, msg) {\n    var size = msg['size'];\n    if (size[0] !== fig.canvas.width || size[1] !== fig.canvas.height) {\n        fig._resize_canvas(size[0], size[1], msg['forward']);\n        fig.send_message('refresh', {});\n    }\n};\n\nmpl.figure.prototype.handle_rubberband = function (fig, msg) {\n    var x0 = msg['x0'] / fig.ratio;\n    var y0 = (fig.canvas.height - msg['y0']) / fig.ratio;\n    var x1 = msg['x1'] / fig.ratio;\n    var y1 = (fig.canvas.height - msg['y1']) / fig.ratio;\n    x0 = Math.floor(x0) + 0.5;\n    y0 = Math.floor(y0) + 0.5;\n    x1 = Math.floor(x1) + 0.5;\n    y1 = Math.floor(y1) + 0.5;\n    var min_x = Math.min(x0, x1);\n    var min_y = Math.min(y0, y1);\n    var width = Math.abs(x1 - x0);\n    var height = Math.abs(y1 - y0);\n\n    fig.rubberband_context.clearRect(\n        0,\n        0,\n        fig.canvas.width / fig.ratio,\n        fig.canvas.height / fig.ratio\n    );\n\n    fig.rubberband_context.strokeRect(min_x, min_y, width, height);\n};\n\nmpl.figure.prototype.handle_figure_label = function (fig, msg) {\n    // Updates the figure title.\n    fig.header.textContent = msg['label'];\n};\n\nmpl.figure.prototype.handle_cursor = function (fig, msg) {\n    fig.canvas_div.style.cursor = msg['cursor'];\n};\n\nmpl.figure.prototype.handle_message = function (fig, msg) {\n    fig.message.textContent = msg['message'];\n};\n\nmpl.figure.prototype.handle_draw = function (fig, _msg) {\n    // Request the server to send over a new figure.\n    fig.send_draw_message();\n};\n\nmpl.figure.prototype.handle_image_mode = function (fig, msg) {\n    fig.image_mode = msg['mode'];\n};\n\nmpl.figure.prototype.handle_history_buttons = function (fig, msg) {\n    for (var key in msg) {\n        if (!(key in fig.buttons)) {\n            continue;\n        }\n        fig.buttons[key].disabled = !msg[key];\n        fig.buttons[key].setAttribute('aria-disabled', !msg[key]);\n    }\n};\n\nmpl.figure.prototype.handle_navigate_mode = function (fig, msg) {\n    if (msg['mode'] === 'PAN') {\n        fig.buttons['Pan'].classList.add('active');\n        fig.buttons['Zoom'].classList.remove('active');\n    } else if (msg['mode'] === 'ZOOM') {\n        fig.buttons['Pan'].classList.remove('active');\n        fig.buttons['Zoom'].classList.add('active');\n    } else {\n        fig.buttons['Pan'].classList.remove('active');\n        fig.buttons['Zoom'].classList.remove('active');\n    }\n};\n\nmpl.figure.prototype.updated_canvas_event = function () {\n    // Called whenever the canvas gets updated.\n    this.send_message('ack', {});\n};\n\n// A function to construct a web socket function for onmessage handling.\n// Called in the figure constructor.\nmpl.figure.prototype._make_on_message_function = function (fig) {\n    return function socket_on_message(evt) {\n        if (evt.data instanceof Blob) {\n            var img = evt.data;\n            if (img.type !== 'image/png') {\n                /* FIXME: We get \"Resource interpreted as Image but\n                 * transferred with MIME type text/plain:\" errors on\n                 * Chrome.  But how to set the MIME type?  It doesn't seem\n                 * to be part of the websocket stream */\n                img.type = 'image/png';\n            }\n\n            /* Free the memory for the previous frames */\n            if (fig.imageObj.src) {\n                (window.URL || window.webkitURL).revokeObjectURL(\n                    fig.imageObj.src\n                );\n            }\n\n            fig.imageObj.src = (window.URL || window.webkitURL).createObjectURL(\n                img\n            );\n            fig.updated_canvas_event();\n            fig.waiting = false;\n            return;\n        } else if (\n            typeof evt.data === 'string' &&\n            evt.data.slice(0, 21) === 'data:image/png;base64'\n        ) {\n            fig.imageObj.src = evt.data;\n            fig.updated_canvas_event();\n            fig.waiting = false;\n            return;\n        }\n\n        var msg = JSON.parse(evt.data);\n        var msg_type = msg['type'];\n\n        // Call the  \"handle_{type}\" callback, which takes\n        // the figure and JSON message as its only arguments.\n        try {\n            var callback = fig['handle_' + msg_type];\n        } catch (e) {\n            console.log(\n                \"No handler for the '\" + msg_type + \"' message type: \",\n                msg\n            );\n            return;\n        }\n\n        if (callback) {\n            try {\n                // console.log(\"Handling '\" + msg_type + \"' message: \", msg);\n                callback(fig, msg);\n            } catch (e) {\n                console.log(\n                    \"Exception inside the 'handler_\" + msg_type + \"' callback:\",\n                    e,\n                    e.stack,\n                    msg\n                );\n            }\n        }\n    };\n};\n\nfunction getModifiers(event) {\n    var mods = [];\n    if (event.ctrlKey) {\n        mods.push('ctrl');\n    }\n    if (event.altKey) {\n        mods.push('alt');\n    }\n    if (event.shiftKey) {\n        mods.push('shift');\n    }\n    if (event.metaKey) {\n        mods.push('meta');\n    }\n    return mods;\n}\n\n/*\n * return a copy of an object with only non-object keys\n * we need this to avoid circular references\n * https://stackoverflow.com/a/24161582/3208463\n */\nfunction simpleKeys(original) {\n    return Object.keys(original).reduce(function (obj, key) {\n        if (typeof original[key] !== 'object') {\n            obj[key] = original[key];\n        }\n        return obj;\n    }, {});\n}\n\nmpl.figure.prototype.mouse_event = function (event, name) {\n    if (name === 'button_press') {\n        this.canvas.focus();\n        this.canvas_div.focus();\n    }\n\n    // from https://stackoverflow.com/q/1114465\n    var boundingRect = this.canvas.getBoundingClientRect();\n    var x = (event.clientX - boundingRect.left) * this.ratio;\n    var y = (event.clientY - boundingRect.top) * this.ratio;\n\n    this.send_message(name, {\n        x: x,\n        y: y,\n        button: event.button,\n        step: event.step,\n        buttons: event.buttons,\n        modifiers: getModifiers(event),\n        guiEvent: simpleKeys(event),\n    });\n\n    return false;\n};\n\nmpl.figure.prototype._key_event_extra = function (_event, _name) {\n    // Handle any extra behaviour associated with a key event\n};\n\nmpl.figure.prototype.key_event = function (event, name) {\n    // Prevent repeat events\n    if (name === 'key_press') {\n        if (event.key === this._key) {\n            return;\n        } else {\n            this._key = event.key;\n        }\n    }\n    if (name === 'key_release') {\n        this._key = null;\n    }\n\n    var value = '';\n    if (event.ctrlKey && event.key !== 'Control') {\n        value += 'ctrl+';\n    }\n    else if (event.altKey && event.key !== 'Alt') {\n        value += 'alt+';\n    }\n    else if (event.shiftKey && event.key !== 'Shift') {\n        value += 'shift+';\n    }\n\n    value += 'k' + event.key;\n\n    this._key_event_extra(event, name);\n\n    this.send_message(name, { key: value, guiEvent: simpleKeys(event) });\n    return false;\n};\n\nmpl.figure.prototype.toolbar_button_onclick = function (name) {\n    if (name === 'download') {\n        this.handle_save(this, null);\n    } else {\n        this.send_message('toolbar_button', { name: name });\n    }\n};\n\nmpl.figure.prototype.toolbar_button_onmouseover = function (tooltip) {\n    this.message.textContent = tooltip;\n};\n\n///////////////// REMAINING CONTENT GENERATED BY embed_js.py /////////////////\n// prettier-ignore\nvar _JSXTOOLS_RESIZE_OBSERVER=function(A){var t,i=new WeakMap,n=new WeakMap,a=new WeakMap,r=new WeakMap,o=new Set;function s(e){if(!(this instanceof s))throw new TypeError(\"Constructor requires 'new' operator\");i.set(this,e)}function h(){throw new TypeError(\"Function is not a constructor\")}function c(e,t,i,n){e=0 in arguments?Number(arguments[0]):0,t=1 in arguments?Number(arguments[1]):0,i=2 in arguments?Number(arguments[2]):0,n=3 in arguments?Number(arguments[3]):0,this.right=(this.x=this.left=e)+(this.width=i),this.bottom=(this.y=this.top=t)+(this.height=n),Object.freeze(this)}function d(){t=requestAnimationFrame(d);var s=new WeakMap,p=new Set;o.forEach((function(t){r.get(t).forEach((function(i){var r=t instanceof window.SVGElement,o=a.get(t),d=r?0:parseFloat(o.paddingTop),f=r?0:parseFloat(o.paddingRight),l=r?0:parseFloat(o.paddingBottom),u=r?0:parseFloat(o.paddingLeft),g=r?0:parseFloat(o.borderTopWidth),m=r?0:parseFloat(o.borderRightWidth),w=r?0:parseFloat(o.borderBottomWidth),b=u+f,F=d+l,v=(r?0:parseFloat(o.borderLeftWidth))+m,W=g+w,y=r?0:t.offsetHeight-W-t.clientHeight,E=r?0:t.offsetWidth-v-t.clientWidth,R=b+v,z=F+W,M=r?t.width:parseFloat(o.width)-R-E,O=r?t.height:parseFloat(o.height)-z-y;if(n.has(t)){var k=n.get(t);if(k[0]===M&&k[1]===O)return}n.set(t,[M,O]);var S=Object.create(h.prototype);S.target=t,S.contentRect=new c(u,d,M,O),s.has(i)||(s.set(i,[]),p.add(i)),s.get(i).push(S)}))})),p.forEach((function(e){i.get(e).call(e,s.get(e),e)}))}return s.prototype.observe=function(i){if(i instanceof window.Element){r.has(i)||(r.set(i,new Set),o.add(i),a.set(i,window.getComputedStyle(i)));var n=r.get(i);n.has(this)||n.add(this),cancelAnimationFrame(t),t=requestAnimationFrame(d)}},s.prototype.unobserve=function(i){if(i instanceof window.Element&&r.has(i)){var n=r.get(i);n.has(this)&&(n.delete(this),n.size||(r.delete(i),o.delete(i))),n.size||r.delete(i),o.size||cancelAnimationFrame(t)}},A.DOMRectReadOnly=c,A.ResizeObserver=s,A.ResizeObserverEntry=h,A}; // eslint-disable-line\nmpl.toolbar_items = [[\"Home\", \"Reset original view\", \"fa fa-home\", \"home\"], [\"Back\", \"Back to previous view\", \"fa fa-arrow-left\", \"back\"], [\"Forward\", \"Forward to next view\", \"fa fa-arrow-right\", \"forward\"], [\"\", \"\", \"\", \"\"], [\"Pan\", \"Left button pans, Right button zooms\\nx/y fixes axis, CTRL fixes aspect\", \"fa fa-arrows\", \"pan\"], [\"Zoom\", \"Zoom to rectangle\\nx/y fixes axis\", \"fa fa-square-o\", \"zoom\"], [\"\", \"\", \"\", \"\"], [\"Download\", \"Download plot\", \"fa fa-floppy-o\", \"download\"]];\n\nmpl.extensions = [\"eps\", \"jpeg\", \"pgf\", \"pdf\", \"png\", \"ps\", \"raw\", \"svg\", \"tif\", \"webp\"];\n\nmpl.default_extension = \"png\";/* global mpl */\n\nvar comm_websocket_adapter = function (comm) {\n    // Create a \"websocket\"-like object which calls the given IPython comm\n    // object with the appropriate methods. Currently this is a non binary\n    // socket, so there is still some room for performance tuning.\n    var ws = {};\n\n    ws.binaryType = comm.kernel.ws.binaryType;\n    ws.readyState = comm.kernel.ws.readyState;\n    function updateReadyState(_event) {\n        if (comm.kernel.ws) {\n            ws.readyState = comm.kernel.ws.readyState;\n        } else {\n            ws.readyState = 3; // Closed state.\n        }\n    }\n    comm.kernel.ws.addEventListener('open', updateReadyState);\n    comm.kernel.ws.addEventListener('close', updateReadyState);\n    comm.kernel.ws.addEventListener('error', updateReadyState);\n\n    ws.close = function () {\n        comm.close();\n    };\n    ws.send = function (m) {\n        //console.log('sending', m);\n        comm.send(m);\n    };\n    // Register the callback with on_msg.\n    comm.on_msg(function (msg) {\n        //console.log('receiving', msg['content']['data'], msg);\n        var data = msg['content']['data'];\n        if (data['blob'] !== undefined) {\n            data = {\n                data: new Blob(msg['buffers'], { type: data['blob'] }),\n            };\n        }\n        // Pass the mpl event to the overridden (by mpl) onmessage function.\n        ws.onmessage(data);\n    });\n    return ws;\n};\n\nmpl.mpl_figure_comm = function (comm, msg) {\n    // This is the function which gets called when the mpl process\n    // starts-up an IPython Comm through the \"matplotlib\" channel.\n\n    var id = msg.content.data.id;\n    // Get hold of the div created by the display call when the Comm\n    // socket was opened in Python.\n    var element = document.getElementById(id);\n    var ws_proxy = comm_websocket_adapter(comm);\n\n    function ondownload(figure, _format) {\n        window.open(figure.canvas.toDataURL());\n    }\n\n    var fig = new mpl.figure(id, ws_proxy, ondownload, element);\n\n    // Call onopen now - mpl needs it, as it is assuming we've passed it a real\n    // web socket which is closed, not our websocket->open comm proxy.\n    ws_proxy.onopen();\n\n    fig.parent_element = element;\n    fig.cell_info = mpl.find_output_cell(\"<div id='\" + id + \"'></div>\");\n    if (!fig.cell_info) {\n        console.error('Failed to find cell for figure', id, fig);\n        return;\n    }\n    fig.cell_info[0].output_area.element.on(\n        'cleared',\n        { fig: fig },\n        fig._remove_fig_handler\n    );\n};\n\nmpl.figure.prototype.handle_close = function (fig, msg) {\n    var width = fig.canvas.width / fig.ratio;\n    fig.cell_info[0].output_area.element.off(\n        'cleared',\n        fig._remove_fig_handler\n    );\n    fig.resizeObserverInstance.unobserve(fig.canvas_div);\n\n    // Update the output cell to use the data from the current canvas.\n    fig.push_to_output();\n    var dataURL = fig.canvas.toDataURL();\n    // Re-enable the keyboard manager in IPython - without this line, in FF,\n    // the notebook keyboard shortcuts fail.\n    IPython.keyboard_manager.enable();\n    fig.parent_element.innerHTML =\n        '<img src=\"' + dataURL + '\" width=\"' + width + '\">';\n    fig.close_ws(fig, msg);\n};\n\nmpl.figure.prototype.close_ws = function (fig, msg) {\n    fig.send_message('closing', msg);\n    // fig.ws.close()\n};\n\nmpl.figure.prototype.push_to_output = function (_remove_interactive) {\n    // Turn the data on the canvas into data in the output cell.\n    var width = this.canvas.width / this.ratio;\n    var dataURL = this.canvas.toDataURL();\n    this.cell_info[1]['text/html'] =\n        '<img src=\"' + dataURL + '\" width=\"' + width + '\">';\n};\n\nmpl.figure.prototype.updated_canvas_event = function () {\n    // Tell IPython that the notebook contents must change.\n    IPython.notebook.set_dirty(true);\n    this.send_message('ack', {});\n    var fig = this;\n    // Wait a second, then push the new image to the DOM so\n    // that it is saved nicely (might be nice to debounce this).\n    setTimeout(function () {\n        fig.push_to_output();\n    }, 1000);\n};\n\nmpl.figure.prototype._init_toolbar = function () {\n    var fig = this;\n\n    var toolbar = document.createElement('div');\n    toolbar.classList = 'btn-toolbar';\n    this.root.appendChild(toolbar);\n\n    function on_click_closure(name) {\n        return function (_event) {\n            return fig.toolbar_button_onclick(name);\n        };\n    }\n\n    function on_mouseover_closure(tooltip) {\n        return function (event) {\n            if (!event.currentTarget.disabled) {\n                return fig.toolbar_button_onmouseover(tooltip);\n            }\n        };\n    }\n\n    fig.buttons = {};\n    var buttonGroup = document.createElement('div');\n    buttonGroup.classList = 'btn-group';\n    var button;\n    for (var toolbar_ind in mpl.toolbar_items) {\n        var name = mpl.toolbar_items[toolbar_ind][0];\n        var tooltip = mpl.toolbar_items[toolbar_ind][1];\n        var image = mpl.toolbar_items[toolbar_ind][2];\n        var method_name = mpl.toolbar_items[toolbar_ind][3];\n\n        if (!name) {\n            /* Instead of a spacer, we start a new button group. */\n            if (buttonGroup.hasChildNodes()) {\n                toolbar.appendChild(buttonGroup);\n            }\n            buttonGroup = document.createElement('div');\n            buttonGroup.classList = 'btn-group';\n            continue;\n        }\n\n        button = fig.buttons[name] = document.createElement('button');\n        button.classList = 'btn btn-default';\n        button.href = '#';\n        button.title = name;\n        button.innerHTML = '<i class=\"fa ' + image + ' fa-lg\"></i>';\n        button.addEventListener('click', on_click_closure(method_name));\n        button.addEventListener('mouseover', on_mouseover_closure(tooltip));\n        buttonGroup.appendChild(button);\n    }\n\n    if (buttonGroup.hasChildNodes()) {\n        toolbar.appendChild(buttonGroup);\n    }\n\n    // Add the status bar.\n    var status_bar = document.createElement('span');\n    status_bar.classList = 'mpl-message pull-right';\n    toolbar.appendChild(status_bar);\n    this.message = status_bar;\n\n    // Add the close button to the window.\n    var buttongrp = document.createElement('div');\n    buttongrp.classList = 'btn-group inline pull-right';\n    button = document.createElement('button');\n    button.classList = 'btn btn-mini btn-primary';\n    button.href = '#';\n    button.title = 'Stop Interaction';\n    button.innerHTML = '<i class=\"fa fa-power-off icon-remove icon-large\"></i>';\n    button.addEventListener('click', function (_evt) {\n        fig.handle_close(fig, {});\n    });\n    button.addEventListener(\n        'mouseover',\n        on_mouseover_closure('Stop Interaction')\n    );\n    buttongrp.appendChild(button);\n    var titlebar = this.root.querySelector('.ui-dialog-titlebar');\n    titlebar.insertBefore(buttongrp, titlebar.firstChild);\n};\n\nmpl.figure.prototype._remove_fig_handler = function (event) {\n    var fig = event.data.fig;\n    if (event.target !== this) {\n        // Ignore bubbled events from children.\n        return;\n    }\n    fig.close_ws(fig, {});\n};\n\nmpl.figure.prototype._root_extra_style = function (el) {\n    el.style.boxSizing = 'content-box'; // override notebook setting of border-box.\n};\n\nmpl.figure.prototype._canvas_extra_style = function (el) {\n    // this is important to make the div 'focusable\n    el.setAttribute('tabindex', 0);\n    // reach out to IPython and tell the keyboard manager to turn it's self\n    // off when our div gets focus\n\n    // location in version 3\n    if (IPython.notebook.keyboard_manager) {\n        IPython.notebook.keyboard_manager.register_events(el);\n    } else {\n        // location in version 2\n        IPython.keyboard_manager.register_events(el);\n    }\n};\n\nmpl.figure.prototype._key_event_extra = function (event, _name) {\n    // Check for shift+enter\n    if (event.shiftKey && event.which === 13) {\n        this.canvas_div.blur();\n        // select the cell after this one\n        var index = IPython.notebook.find_cell_index(this.cell_info[0]);\n        IPython.notebook.select(index + 1);\n    }\n};\n\nmpl.figure.prototype.handle_save = function (fig, _msg) {\n    fig.ondownload(fig, null);\n};\n\nmpl.find_output_cell = function (html_output) {\n    // Return the cell and output element which can be found *uniquely* in the notebook.\n    // Note - this is a bit hacky, but it is done because the \"notebook_saving.Notebook\"\n    // IPython event is triggered only after the cells have been serialised, which for\n    // our purposes (turning an active figure into a static one), is too late.\n    var cells = IPython.notebook.get_cells();\n    var ncells = cells.length;\n    for (var i = 0; i < ncells; i++) {\n        var cell = cells[i];\n        if (cell.cell_type === 'code') {\n            for (var j = 0; j < cell.output_area.outputs.length; j++) {\n                var data = cell.output_area.outputs[j];\n                if (data.data) {\n                    // IPython >= 3 moved mimebundle to data attribute of output\n                    data = data.data;\n                }\n                if (data['text/html'] === html_output) {\n                    return [cell, data, j];\n                }\n            }\n        }\n    }\n};\n\n// Register the function which deals with the matplotlib target/channel.\n// The kernel may be null if the page has been refreshed.\nif (IPython.notebook.kernel !== null) {\n    IPython.notebook.kernel.comm_manager.register_target(\n        'matplotlib',\n        mpl.mpl_figure_comm\n    );\n}\n"
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ],
-      "text/html": [
-       "<div id='d282cecd-4b50-4870-bc83-33df3eb4e787'></div>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "execution_count": 7
+   "outputs": [],
+   "execution_count": null
   }
  ],
  "metadata": {

--- a/tests/test_dijkstra.py
+++ b/tests/test_dijkstra.py
@@ -40,10 +40,9 @@ class TestDijkstraGeneric:
         # make sure the algorithm does not go through walls or out of bounds
         cost = np.array([[1, np.inf, 1], [1, np.inf, 1], [1, np.inf, 1]])
         pathing = cy_dijkstra(cost, np.array([[1, 2]]))
-        distance_expected = np.array(
-            [[np.inf, np.inf, 2], [np.inf, np.inf, 1], [np.inf, np.inf, 2]]
-        )
-        assert_equal(pathing.distance, distance_expected)
+        assert_equal(pathing.get_path((0, 0)), [(0, 0)])
+        assert_equal(pathing.get_path((1, 0)), [(1, 0)])
+        assert_equal(pathing.get_path((2, 0)), [(2, 0)])
 
     def test_find_valid_start(self):
         # test that the algorithm searches for valid starting point near the given coordinates
@@ -58,30 +57,39 @@ class TestDijkstraGeneric:
         assert_equal(pathing.get_path((0.1, 2)), [(1, 2), (2, 2)])
         assert_equal(pathing.get_path((-2.2, 6.9), max_distance=5), [(1, 3), (2, 2)])
 
+    def test_dtypes(self):
+        """test that the algorithm accepts different kinds of dtypes"""
+        cost = np.ones((3, 3))
+        targets = np.array([(1, 1)])
+        cy_dijkstra(cost.astype(np.float32), targets.astype(np.int32))
+        cy_dijkstra(cost.astype(np.float64), targets.astype(np.int64))
+        cy_dijkstra(cost.astype(np.int32), targets.astype(int))
 
-@pytest.mark.parametrize("bot", MAPS, indirect=True)
+
 class TestDijkstra:
-    scenarios = [(map_path.name, {"map_path": map_path}) for map_path in MAPS]
 
-    def test_pathing(self, bot: BotAI, event_loop):
-        targets = np.array([u.position.rounded for u in bot.enemy_units], np.intp)
-        cost = np.where(
-            bot.game_info.pathing_grid.data_numpy.T == 1, 1.0, np.inf
-        ).astype(np.float64)
+    def test_maze1(self):
+        """test that simple maze can be solved and that diagonals are used."""
+        x = np.inf
+        cost = np.array([
+            [1, x, 1, 1, 1],
+            [1, 1, 2, x, 1],
+        ])
+        targets = np.array([[1, 4]])
         pathing = cy_dijkstra(cost, targets)
+        assert_equal(pathing.get_path((0, 0)), [(0, 0), (1, 1), (0, 2), (0, 3), (1, 4)])
 
-        limit = 32
-        for unit in bot.units:
-            p = unit.position.rounded
-            path = pathing.get_path(p, limit)
-            assert 1 <= len(path) <= limit
-            if len(path) == 1:
-                assert pathing.distance[path[0]] == np.inf
-            else:
-                # test that the distance was calculated correctly along the path
-                path_backwards = path[::-1]
-                dist_expected = pathing.distance[path_backwards[0]]
-                for i, (p, q) in enumerate(zip(path_backwards[1:], path_backwards)):
-                    dist_factor = np.linalg.norm(np.array(p) - np.array(q))
-                    dist_expected += cost[p] * dist_factor
-                    assert pathing.distance[p] == dist_expected
+    def test_maze2(self):
+        """test that obstacles are avoided correctly."""
+        x = np.inf
+        cost = np.array([
+            [1, 1, 1, 2, 1],
+            [1, x, x, x, 1],
+            [1, x, x, x, 1],
+            [1, x, x, x, 1],
+            [1, 1, 1, 1, 1],
+        ])
+        targets = np.array([[4, 4]])
+        pathing = cy_dijkstra(cost, targets)
+        assert_equal(pathing.get_path((0, 0)), [(0, 0), (1, 0), (2, 0), (3, 0), (4, 1), (4, 2), (4, 3), (4, 4)])
+        assert_equal(pathing.get_path((0, 2)), [(0, 2), (0, 3), (1, 4), (2, 4), (3, 4), (4, 4)])


### PR DESCRIPTION
This PR defers the evaluation of `cy_dijkstra` and adds a bunch of optimizations under the hood. The API is unchanged, except for some auxiliary grids that are no longer accessible.

### :white_check_mark: Major changes:
- lazy evaluation / early return: `cy_dijkstra` only allocates grids and initializes the priority queue. expansion of nodes is defered until `get_path` is called
- more flexible input data, convert cost to `float32` and targets to `int32` if needed
- source coordinates are rounded properly

### :warning: Breaking Changes
- `DijkstraOutput` renamed to `DijkstraPathing` (idea: reflect where the actual computation happens)
- distance grid is no longer accessible to the user (since entries might not be final)
- forward pointer grid removed (now encoded internally as uint8 for efficiency)

### :information_source: Implementation notes:
- extracted hot loop to `cdef` function
- use flattened grids and raw pointers for speed
- switched from 4-ary heap to binary heap (ends up slightly faster due to simpler `bubble_down`)

### :watch: Performance
- for fair comparison with eager dijkstra, timing includes an initial query across the map
- `%timeit cy_dijkstra(cost, targets).get_path(bot.enemy_start_locations[0])`
    - before: 1.08 ms ± 12.7 μs
    - after: 521 μs ± 14 μs
- `%timeit pathing.get_path(bot.enemy_start_locations[0])`
    - before: 7.73 μs ± 543 ns
    - after: 3.61 μs ± 92.9 ns
- `%timeit pathing.get_path(bot.enemy_start_locations[0], 3)`
    - before: 2.54 μs ± 54.7 ns
    - after: 838 ns ± 21.4 ns