### PR TITLE
fix: accept readonly buffers in cy_dijkstra

### DIFF
--- a/cython_extensions/dijkstra.pyx
+++ b/cython_extensions/dijkstra.pyx
@@ -177,8 +177,8 @@ cdef class DijkstraPathing:
     cdef INDEX_t stride
 
     def __cinit__(self,
-                  DTYPE_t[:, ::1] cost,
-                  INDEX_t[:, ::1] targets):
+                  const DTYPE_t[:, ::1] cost,
+                  const INDEX_t[:, ::1] targets):
         cdef INDEX_t num_targets = targets.shape[0]
         self.cost = np.pad(cost, 1, "constant", constant_values=INFINITY)
         self.stride = self.cost.shape[1]
@@ -312,8 +312,8 @@ cpdef DijkstraPathing cy_dijkstra(
         Pathfinding object containing containing distance and forward pointer grids.
 
     """
-    cdef DTYPE_t[:, ::1] cost_array = np.ascontiguousarray(cost, dtype=np.float32)
-    cdef INDEX_t[:, ::1] target_array = np.ascontiguousarray(targets, dtype=np.int32)
+    cdef const DTYPE_t[:, ::1] cost_array = np.ascontiguousarray(cost, dtype=np.float32)
+    cdef const INDEX_t[:, ::1] target_array = np.ascontiguousarray(targets, dtype=np.int32)
     if checks_enabled:
         if not np.greater(cost_array, 0.0).all():
             raise Exception("invalid cost: values must be positive")

--- a/tests/test_dijkstra.py
+++ b/tests/test_dijkstra.py
@@ -65,6 +65,16 @@ class TestDijkstraGeneric:
         cy_dijkstra(cost.astype(np.float64), targets.astype(np.int64))
         cy_dijkstra(cost.astype(np.int32), targets.astype(int))
 
+    def test_accepts_readonly_inputs(self):
+        cost = np.ones((8, 8), dtype=np.float32)
+        cost.flags.writeable = False
+        targets = np.array([(3, 3)], dtype=np.int32)
+        targets.flags.writeable = False
+
+        pathing = cy_dijkstra(cost, targets)
+
+        assert pathing.get_path((0, 0))
+
 
 class TestDijkstra:
 


### PR DESCRIPTION
`cy_dijkstra` never writes to  `cost` and `target` , but readonly inputs are rejected.

## Reproduction

```py
cost = np.ones((8, 8), dtype=np.float32)
cost.flags.writeable = False
targets = np.array([(3, 3)], dtype=np.int32)
cy_dijkstra(cost, targets)
```

results in

`ValueError: buffer source array is read-only`.

## Proposed Fix

Mark the memory views as `const`. This skips the mutability check, so it should be a strict generalization.