### PR TITLE
feat: add `get_distance` to `DijkstraPathing`

### DIFF
--- a/cython_extensions/dijkstra.pyi
+++ b/cython_extensions/dijkstra.pyi
@@ -3,6 +3,25 @@ import numpy as np
 class DijkstraPathing:
     """Result of Dijkstras algorithm containing distance and forward pointer grids."""
 
+    def get_distance(
+        self, source: tuple[int, int], upper_bound: bool = False
+    ) -> float:
+        """Get the pathing distance from a given source to the nearest target.
+
+        Args:
+            source: Start point as integer grid coordinates.
+            upper_bound: If `True`, return the current distance estimate without
+                advancing the heap. Defaults to `False`.
+
+        Returns:
+            The lowest cost from source to any of the targets.
+
+        Raises:
+            IndexError: If source is outside the cost grid bounds.
+
+        """
+        ...
+
     def get_path(
         self, source: tuple[float, float], limit: int = 0, max_distance: int = 1
     ) -> list[tuple[int, int]]:

--- a/cython_extensions/dijkstra.pyi
+++ b/cython_extensions/dijkstra.pyi
@@ -4,20 +4,17 @@ class DijkstraPathing:
     """Result of Dijkstras algorithm containing distance and forward pointer grids."""
 
     def get_distance(
-        self, source: tuple[int, int], upper_bound: bool = False
+        self, source: tuple[float, float], upper_bound: bool = False
     ) -> float:
         """Get the pathing distance from a given source to the nearest target.
 
         Args:
-            source: Start point as integer grid coordinates.
+            source: Start point.
             upper_bound: If `True`, return the current distance estimate without
                 advancing the heap. Defaults to `False`.
 
         Returns:
             The lowest cost from source to any of the targets.
-
-        Raises:
-            IndexError: If source is outside the cost grid bounds.
 
         """
         ...

--- a/cython_extensions/dijkstra.pyx
+++ b/cython_extensions/dijkstra.pyx
@@ -212,6 +212,20 @@ cdef class DijkstraPathing:
         PyMem_Free(self.index)
         PyMem_Free(self.priority)
 
+    cdef void _advance_heap(self, INDEX_t start):
+        dijkstra_core(
+            &self.index,
+            &self.priority,
+            &self.capacity,
+            &self.indirection[0, 0],
+            &self.size,
+            start,
+            &self.distance[0, 0],
+            &self.cost[0, 0],
+            &self.direction[0, 0],
+            self.stride
+        )
+
     cpdef get_path(self, object source, int limit=0, int max_distance=1):
         """
 
@@ -236,19 +250,42 @@ cdef class DijkstraPathing:
         x0, y0 = self._find_starting_point(np.asarray(source, dtype=np.float32), max_distance=max_distance)
         if x0 < 0 or y0 < 0 or x0 >= self.cost.shape[0] or y0 >= self.cost.shape[1] or self.cost[x0, y0] == INFINITY:
             return [(x0 - 1, y0 - 1)]
-        dijkstra_core(
-            &self.index,
-            &self.priority,
-            &self.capacity,
-            &self.indirection[0, 0],
-            &self.size,
-            x0 * self.stride + y0,
-            &self.distance[0, 0],
-            &self.cost[0, 0],
-            &self.direction[0, 0],
-            self.stride
-        )
+        self._advance_heap(x0 * self.stride + y0)
         return self._follow_directions(x0, y0, limit)
+
+    cpdef DTYPE_t get_distance(self, tuple source, bint upper_bound=False):
+        """
+
+        Get the pathing distance from a given source to the nearest target.
+
+        Parameters
+        ----------
+        source :
+            Start point as integer grid coordinates.
+        upper_bound :
+            If False (default), compute exact distance by advancing the heap.
+            If True, return current distance estimate without advancing.
+
+        Returns
+        -------
+        float :
+            The lowest cost from source to any of the targets.
+
+        Raises
+        ------
+        IndexError :
+            If source is outside the cost grid bounds.
+
+        """
+        cdef INDEX_t x0 = source[0]
+        cdef INDEX_t y0 = source[1]
+        if x0 < 0 or y0 < 0 or x0 >= self.cost.shape[0] - 2 or y0 >= self.cost.shape[1] - 2:
+            raise IndexError("source coordinates out of bounds")
+        x0 += 1
+        y0 += 1
+        if not upper_bound:
+            self._advance_heap(x0 * self.stride + y0)
+        return self.distance[x0, y0]
 
     cdef _follow_directions(self, INDEX_t x, INDEX_t y, INDEX_t limit):
         if limit == 0:

--- a/cython_extensions/dijkstra.pyx
+++ b/cython_extensions/dijkstra.pyx
@@ -253,7 +253,7 @@ cdef class DijkstraPathing:
         self._advance_heap(x0 * self.stride + y0)
         return self._follow_directions(x0, y0, limit)
 
-    cpdef DTYPE_t get_distance(self, tuple source, bint upper_bound=False):
+    cpdef DTYPE_t get_distance(self, object source, bint upper_bound=False):
         """
 
         Get the pathing distance from a given source to the nearest target.
@@ -261,7 +261,7 @@ cdef class DijkstraPathing:
         Parameters
         ----------
         source :
-            Start point as integer grid coordinates.
+            Start point.
         upper_bound :
             If False (default), compute exact distance by advancing the heap.
             If True, return current distance estimate without advancing.
@@ -271,18 +271,11 @@ cdef class DijkstraPathing:
         float :
             The lowest cost from source to any of the targets.
 
-        Raises
-        ------
-        IndexError :
-            If source is outside the cost grid bounds.
-
         """
-        cdef INDEX_t x0 = source[0]
-        cdef INDEX_t y0 = source[1]
-        if x0 < 0 or y0 < 0 or x0 >= self.cost.shape[0] - 2 or y0 >= self.cost.shape[1] - 2:
-            raise IndexError("source coordinates out of bounds")
-        x0 += 1
-        y0 += 1
+        cdef INDEX_t x0, y0
+        x0, y0 = self._find_starting_point(np.asarray(source, dtype=np.float32), max_distance=1)
+        if x0 < 0 or y0 < 0 or x0 >= self.cost.shape[0] or y0 >= self.cost.shape[1] or self.cost[x0, y0] == INFINITY:
+            return INFINITY
         if not upper_bound:
             self._advance_heap(x0 * self.stride + y0)
         return self.distance[x0, y0]

--- a/notebooks/dijkstra.ipynb
+++ b/notebooks/dijkstra.ipynb
@@ -1,151 +1,211 @@
 {
  "cells": [
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "## Pathing Testbed",
-   "id": "7ac6666e-e599-4712-bb0e-c1774591efe8"
-  },
-  {
-   "cell_type": "code",
-   "id": "ed24b807-8666-46d5-822d-c5345890cbaa",
+   "id": "7ac6666e-e599-4712-bb0e-c1774591efe8",
    "metadata": {},
    "source": [
-    "# Change path as needed\n",
-    "MAP_PATH = \"../tests/pickle_data/AncientCisternAIE.xz\""
-   ],
-   "outputs": [],
-   "execution_count": null
+    "## Pathing Testbed"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "832ef3d4-55c0-4c5f-b2a3-324444e90539",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-09T16:24:34.544963300Z",
+     "start_time": "2025-12-09T16:24:34.491062300Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "# load cell magic things\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "%load_ext line_profiler\n",
     "%load_ext Cython"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
-   "id": "43e201a3-e828-4568-b1ee-802502cf4ee6",
-   "metadata": {},
+   "execution_count": null,
+   "id": "f588c81e196707ca",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-09T16:24:34.564212500Z",
+     "start_time": "2025-12-09T16:24:34.551963600Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "# imports\n",
     "from matplotlib.backend_bases import MouseButton\n",
+    "from pathlib import Path\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
+    "import random\n",
     "\n",
     "from sc2.ids.unit_typeid import UnitTypeId\n",
     "from sc2.bot_ai import BotAI\n",
     "from sc2.position import Point2\n",
     "from sc2.dicts.unit_trained_from import UNIT_TRAINED_FROM\n",
-    "from sc2.game_info import Race\n",
+    "from sc2.data import Race\n",
     "from sc2.unit import Unit\n",
     "from sc2.units import Units\n",
     "\n",
     "from cython_extensions import cy_dijkstra\n",
     "\n",
     "from tests.load_bot_from_pickle import get_map_specific_bot"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
-   "id": "f7ded910-3843-4148-9c48-4acdaf81bbd0",
+   "execution_count": null,
+   "id": "3afb1a6e",
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Change path as needed\n",
+    "MAP_PATH = Path(\"../tests/pickle_data/AncientCisternAIE.xz\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b49362e955fe98f",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-09T16:24:34.728856400Z",
+     "start_time": "2025-12-09T16:24:34.571534600Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "# setup a burnysc2 BOTAI instance we can test with\n",
     "bot: BotAI = get_map_specific_bot(MAP_PATH)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "32568a9857fe459c",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-09T16:24:34.739797700Z",
+     "start_time": "2025-12-09T16:24:34.728856400Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "cost = np.where(bot.game_info.pathing_grid.data_numpy.T == 1, 1.0, np.inf)\n",
     "targets_test = np.array([u.position.rounded for u in bot.units])"
-   ],
-   "id": "32568a9857fe459c",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "source": "%timeit cy_dijkstra(cost, targets_test).get_path(bot.enemy_start_locations[0])",
-   "id": "104dd9a70768eb3",
+   "execution_count": null,
+   "id": "26aa5cd732070866",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-09T16:24:47.952733600Z",
+     "start_time": "2025-12-09T16:24:34.739797700Z"
+    }
+   },
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "%%timeit -n 10\n",
+    "cy_dijkstra(cost, targets_test)"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "b60ad6c9516ded59",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-09T16:24:58.754102Z",
+     "start_time": "2025-12-09T16:24:58.743592300Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "pathing = cy_dijkstra(cost, targets_test)\n",
-    "pathing.get_path(bot.enemy_start_locations[0], 3)"
-   ],
-   "id": "676a44e3e5484c71",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "metadata": {},
-   "cell_type": "code",
-   "source": "%timeit pathing.get_path(bot.enemy_start_locations[0])",
-   "id": "77e0a431c03650cb",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "metadata": {},
-   "cell_type": "code",
-   "source": "%timeit pathing.get_path(bot.enemy_start_locations[0], 3)",
-   "id": "4d44170637d32b0a",
-   "outputs": [],
-   "execution_count": null
+    "sources_test = [u.position.rounded for u in bot.enemy_start_locations]"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "9f5fb567-809a-4823-aefa-569a2b21cf25",
-   "metadata": {},
+   "execution_count": null,
+   "id": "8ebbbe61e0cfa6a3",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-09T16:25:19.514132700Z",
+     "start_time": "2025-12-09T16:25:13.688327500Z"
+    }
+   },
+   "outputs": [],
    "source": [
-    "pathing = None\n",
-    "targets = set()\n",
-    "source = 0, 0\n",
+    "%%timeit -n 10\n",
+    "pathing.get_path(random.choice(sources_test))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6318f2e460243b6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 8))\n",
     "\n",
-    "fig, ax = plt.subplots()\n",
-    "ax.set_title(\"Leftclick to add target. Rightclick to reset.\")\n",
-    "img = ax.imshow(cost, picker=True)\n",
-    "fig.colorbar(img)\n",
+    "ax.set_title(MAP_PATH.stem, fontsize=14, fontweight='bold')\n",
+    "\n",
+    "img = ax.imshow(cost, picker=True, cmap='viridis', vmin=1)\n",
+    "img.cmap.set_under('black')\n",
+    "cbar = fig.colorbar(img)\n",
+    "cbar.set_label('Distance', fontsize=12)\n",
+    "\n",
+    "# Add usage instructions as text\n",
+    "usage_text = \"Left-click: Add target\\nRight-click: Reset\\nMove mouse: Set source\"\n",
+    "ax.text(0.02, 0.98, usage_text, transform=ax.transAxes,\n",
+    "        fontsize=10, verticalalignment='top',\n",
+    "        bbox=dict(boxstyle='round', facecolor='wheat', alpha=0.8))\n",
+    "fig.tight_layout()\n",
+    "\n",
+    "\n",
+    "targets = []\n",
+    "data = cost\n",
     "\n",
     "def draw():\n",
-    "    if pathing is None:\n",
+    "    if pathing is None or not any(targets):\n",
     "        data = cost\n",
     "    else:\n",
-    "        data = cost.copy()\n",
+    "        data = np.array([\n",
+    "            [pathing.get_distance((x, y), upper_bound=True) for y in range(cost.shape[1])]\n",
+    "            for x in range(cost.shape[0])\n",
+    "        ])\n",
     "        for p in pathing.get_path(source):\n",
-    "            data[p] = np.nan\n",
+    "            data[p] = 0.0\n",
     "        for t in targets:\n",
-    "            data[t] = np.nan\n",
+    "            data[t] = 0.0\n",
     "    img.set_array(data)\n",
-    "    img.set_clim(vmax=np.ma.masked_invalid(data).max())\n",
+    "    img.set_clim(vmin=1, vmax=np.ma.masked_invalid(data).max())\n",
     "    fig.canvas.flush_events()\n",
     "    \n",
     "def pick_target(event):\n",
     "    global pathing\n",
+    "    if event.xdata is None or event.ydata is None:\n",
+    "        return\n",
     "    p = int(event.ydata), int(event.xdata)\n",
+    "    # Check if click is within bounds\n",
+    "    if not (0 <= p[0] < cost.shape[0] and 0 <= p[1] < cost.shape[1]):\n",
+    "        return\n",
     "    if event.button is MouseButton.LEFT:\n",
     "        if cost[p] < np.inf:\n",
-    "            targets.add(p)\n",
-    "        pathing = cy_dijkstra(cost, np.array(list(targets)))\n",
+    "            targets.append(p)\n",
+    "        if targets:\n",
+    "            target_coords = np.asarray(targets, dtype=np.int64).reshape(-1, 2)\n",
+    "            pathing = cy_dijkstra(cost, target_coords)\n",
     "    elif event.button is MouseButton.RIGHT:\n",
     "        targets.clear()\n",
     "        pathing = None\n",
@@ -153,20 +213,25 @@
     "\n",
     "def pick_source(event):\n",
     "    global source\n",
-    "    source = int(event.ydata), int(event.xdata)\n",
+    "    if event.xdata is None or event.ydata is None:\n",
+    "        return\n",
+    "    x = int(event.ydata)\n",
+    "    y = int(event.xdata)\n",
+    "    # Check if click is within bounds\n",
+    "    if not (0 <= x < cost.shape[0] and 0 <= y < cost.shape[1]):\n",
+    "        return\n",
+    "    source = x, y\n",
     "    draw()\n",
     "\n",
     "fig.canvas.mpl_connect('button_press_event', pick_target)\n",
     "fig.canvas.mpl_connect('motion_notify_event', pick_source)\n",
     "plt.show()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -180,7 +245,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/tests/test_dijkstra.py
+++ b/tests/test_dijkstra.py
@@ -93,3 +93,20 @@ class TestDijkstra:
         pathing = cy_dijkstra(cost, targets)
         assert_equal(pathing.get_path((0, 0)), [(0, 0), (1, 0), (2, 0), (3, 0), (4, 1), (4, 2), (4, 3), (4, 4)])
         assert_equal(pathing.get_path((0, 2)), [(0, 2), (0, 3), (1, 4), (2, 4), (3, 4), (4, 4)])
+
+
+    def test_distance(self):
+        cost = np.ones((3, 3))
+        targets = np.array([[2, 2]])
+        pathing = cy_dijkstra(cost, targets)
+
+        # estimate should be at maximum
+        for source in ((0, 0), (0, 1), (1, 0), (1, 1)):
+            assert np.isinf(pathing.get_distance(source, upper_bound=True))
+
+        actual = pathing.get_distance((0, 0))
+        estimate = pathing.get_distance((0, 0), upper_bound=True)
+
+        # after heap advance, upper bound should match settled distance
+        assert np.isfinite(actual)
+        assert_equal(estimate, actual)


### PR DESCRIPTION
This PR adds distance queries to the `cy_dijsktra` result:

```py
pathing = cy_dijkstra(cost, targets)
d = pathing.get_distance(unit.position)
```

Since lazy evaluation was implemented in [PR#37](https://github.com/AresSC2/cython-extensions-sc2/pull/37) and made the distance grid a private upper bound, this makes more sense as a function:

- advance the heap as needed and return true distance
- alternatively, use `pathing.get_distance(..., upper_bound=True)` for direct estimate lookup in O(1)

The PR also repairs and polishes the testing notebook which still relied on the inaccessible distance grid.